### PR TITLE
Preparation for GCloud deploy

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,20 +1,26 @@
 <template>
   <div id="app">
     <Header id="nav" />
-    <router-view />
+    <b-overlay :show="isLoading" spinner-variant="danger" :opacity="1" fluid>
+      <router-view />
+    </b-overlay>
   </div>
 </template>
 
 <script>
 import { Header } from "./components";
+import { mapState } from "vuex";
 
 export default {
   name: "App",
   components: {
-    Header,
+    Header
   },
   data() {
     return {};
   },
+  computed: {
+    ...mapState(["isLoading"])
+  }
 };
 </script>

--- a/src/components/Upload.vue
+++ b/src/components/Upload.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="upload-file">
-    <b-container v-if="!isLoading">
+    <b-container>
       <b-form-file
         class="file-selector"
         v-model="file"
@@ -11,42 +11,28 @@
       ></b-form-file>
       <div class="upload-buttons">
         <b-button @click="clearFiles" class="mr-2">Clear file</b-button>
-        <b-button
-          :disabled="!file"
-          @click="submitFiles(file)"
-          class="mr-2"
-          variant="success"
-          >Submit</b-button
-        >
+        <b-button :disabled="!file" @click="submitFiles(file)" class="mr-2" variant="success">Submit</b-button>
       </div>
-      <div class="selected-file mt-3">
-        Selected file: {{ file ? file.name : "" }}
-      </div>
-    </b-container>
-    <b-container v-else fluid>
-      <b-spinner variant="danger" />
+      <div class="selected-file mt-3">Selected file: {{ file ? file.name : "" }}</div>
     </b-container>
   </div>
 </template>
 
 <script>
-import { mapActions, mapState } from "vuex";
+import { mapActions } from "vuex";
 
 export default {
   name: "Upload",
   data() {
     return {
-      file: null,
+      file: null
     };
   },
-  computed: {
-    ...mapState(["isLoading"]),
-  },
   methods: {
-    ...mapActions(["searchReportData", "submitFiles"]),
+    ...mapActions(["submitFiles"]),
     clearFiles() {
       this.file = null;
-    },
-  },
+    }
+  }
 };
 </script>

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -1,7 +1,7 @@
 import axios from "axios";
 const searchData = async (body) => {
   return await axios
-    .post(`${process.env.VUE_APP_DATA_ENDPOINT}/search`, body)
+    .post(`${process.env.VUE_APP_DATA_ENDPOINT}`, body)
     .then((res) => res.data.items)
     .catch((err) => console.log(err));
 };

--- a/src/views/Reports.vue
+++ b/src/views/Reports.vue
@@ -1,39 +1,23 @@
 <template>
   <div class="main-content home">
-    <Tables v-if="!isLoading" :items="reportData" />
-    <b-container v-else fluid>
-      <b-spinner variant="danger" />
-    </b-container>
+    <Tables :items="reportData" />
   </div>
 </template>
 
 <script>
 import { Tables } from "../components";
-import { mapActions, mapState } from "vuex";
+import { mapState } from "vuex";
 
 export default {
   name: "Reports",
   components: {
-    Tables,
+    Tables
   },
   data() {
     return {};
   },
   computed: {
-    ...mapState(["reportData", "isLoading"]),
-  },
-  methods: {
-    ...mapActions(["searchReportData"]),
-    async searchData(body) {
-      await this.searchReportData(body);
-    },
-  },
-  async created() {
-    await this.searchData({
-      title: "rolex",
-      dateTo: "",
-      dateFrom: "",
-    });
-  },
+    ...mapState(["reportData"])
+  }
 };
 </script>


### PR DESCRIPTION
closing #2 

- removing `/search` as the gcloud version will not have this for the endpoint

- removing use of `created` for the reports page. now relies on data uploaded via the upload component (not properly integrated yet)

- moved loading spinner to app level, using overlay instead now as it handles covering the main content nicely